### PR TITLE
Set markTextureNonReadable when generating video thumbnail Texture2D

### DIFF
--- a/Plugins/NativeGallery/NativeGallery.cs
+++ b/Plugins/NativeGallery/NativeGallery.cs
@@ -674,7 +674,7 @@ public static class NativeGallery
 		return result;
 	}
 
-	public static Texture2D GetVideoThumbnail( string videoPath, int maxSize = -1, double captureTimeInSeconds = -1.0 )
+	public static Texture2D GetVideoThumbnail( string videoPath, int maxSize = -1, double captureTimeInSeconds = -1.0, bool markTextureNonReadable = true )
 	{
 		if( maxSize <= 0 )
 			maxSize = SystemInfo.maxTextureSize;
@@ -688,7 +688,7 @@ public static class NativeGallery
 #endif
 
 		if( !string.IsNullOrEmpty( thumbnailPath ) )
-			return LoadImageAtPath( thumbnailPath, maxSize );
+			return LoadImageAtPath( thumbnailPath, maxSize, markTextureNonReadable );
 		else
 			return null;
 	}


### PR DESCRIPTION
Hi @yasirkula! 

First of all thank you very much for all your great libraries :) I was trying to read the Texture2D from the video thumbnail as I was already doing when using `LoadImageAtPath` and realized that the parameter `markTextureNonReadable` wasn't passed. 

Thanks