### PR TITLE
Apply [Flags] attribute for NativeGallery.MediaType

### DIFF
--- a/Plugins/NativeGallery/NativeGallery.cs
+++ b/Plugins/NativeGallery/NativeGallery.cs
@@ -42,6 +42,8 @@ public static class NativeGallery
 
 	public enum PermissionType { Read = 0, Write = 1 };
 	public enum Permission { Denied = 0, Granted = 1, ShouldAsk = 2 };
+	
+	[Flags]
 	public enum MediaType { Image = 1, Video = 2, Audio = 4 };
 
 	// EXIF orientation: http://sylvana.net/jpegcrop/exif_orientation.html (indices are reordered)


### PR DESCRIPTION
The [Flags] attribute should be used whenever the enumerable represents a collection of possible values, rather than a single value. 